### PR TITLE
Add `prettier` config from `mongochangestream`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongochangestream-testing",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mongochangestream-testing",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "ISC",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",

--- a/package.json
+++ b/package.json
@@ -28,5 +28,19 @@
   "dependencies": {
     "@faker-js/faker": "^9.3.0",
     "mongodb": "^6.12.0"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "es5",
+    "plugins": [
+      "@trivago/prettier-plugin-sort-imports"
+    ],
+    "importOrder": [
+      "^[./]"
+    ],
+    "importOrderSortSpecifiers": true,
+    "importOrderCaseInsensitive": true,
+    "importOrderSeparation": true
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import { faker } from '@faker-js/faker'
 import {
-  type Document,
+  type AnyBulkWriteOperation,
   type Collection,
   type Db,
-  type AnyBulkWriteOperation,
+  type Document,
 } from 'mongodb'
 
 export const schema: Document = {


### PR DESCRIPTION
I copied over the `prettier` config from `mongochangestream` in `package.json` so that my editor will format the code the right way.

Other incidental changes:

* After doing the above, when I saved `index.ts`, it fixed the order in one of the imports.
* When I ran `npm install`, it updated the version number in `package-lock.json` to be consistent with `package.json`.